### PR TITLE
remove source type in favor of contextualized source IDs 

### DIFF
--- a/sevco_shell/builders/builder.py
+++ b/sevco_shell/builders/builder.py
@@ -1,16 +1,22 @@
 from getpass import getpass
-from typing import List
+from typing import Callable, List
 
 
 class Builder:
     @staticmethod
-    def get_input(prompt: str, required: bool = True) -> str:
-        if required:
-            prompt = f"{prompt} (required)"
+    def get_input(prompt: str, required: bool = True, validator: Callable = lambda x: True, invalid_message: str = '') -> str:
+        while True:
+            if required:
+                prompt = f"{prompt} (required)"
 
-        val = input(f"{prompt}: ")
-        while val == "" and required:
             val = input(f"{prompt}: ")
+            while (val == "" and required):
+                val = input(f"{prompt}: ")
+
+            if not validator(val):
+                print(invalid_message)
+            else:
+                break
 
         return val
 

--- a/sevco_shell/builders/source.py
+++ b/sevco_shell/builders/source.py
@@ -29,11 +29,22 @@ class SourceBuilder(Builder):
         return self
 
     def _from_user(self) -> SourceInput:
+        def is_valid_id(x: str) -> bool:
+            if len(x) > 32:
+                return False
+
+            for c in x:
+                if not c.isalnum() or c == '-':
+                    return False
+
+            return True
+
+        id = self.get_input("ID", True, is_valid_id, "ID must be no more than 32 characters in kebab case")
         display_name = self.get_input("Display Name")
         is_cloud = self.get_yes_no("Cloud")
         is_public = self.get_yes_no("Public")
 
-        return SourceInput(is_cloud, is_public, display_name)
+        return SourceInput(id, is_cloud, is_public, display_name)
 
     def build(self) -> Optional[Source]:
         if self.source_input:
@@ -99,8 +110,7 @@ class SourceSchemaBuilder(Builder):
                                           settings=schema.settings['title']) for schema in all_schemas]
             by_name.append(self.schemas)
 
-            schemas = self.client.add(
-                self.source_id, source_schemas=SourceSchemaByNameArray(types=by_name))
+            self.client.add(self.source_id, source_schemas=SourceSchemaByNameArray(types=by_name))
             print("Schemas added")
 
             return self.schemas

--- a/sevco_shell/builders/source.py
+++ b/sevco_shell/builders/source.py
@@ -29,13 +29,11 @@ class SourceBuilder(Builder):
         return self
 
     def _from_user(self) -> SourceInput:
-        source_type = self.get_input("Source Type")  # TODO: check format
         display_name = self.get_input("Display Name")
         is_cloud = self.get_yes_no("Cloud")
         is_public = self.get_yes_no("Public")
 
-        return SourceInput(
-            source_type, is_cloud, is_public, display_name)
+        return SourceInput(is_cloud, is_public, display_name)
 
     def build(self) -> Optional[Source]:
         if self.source_input:

--- a/sevco_shell/clients/source_catalog/models.py
+++ b/sevco_shell/clients/source_catalog/models.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 @dataclass
 class SourceInput(with_dict):
-    source_type: str
+    id: str
     is_cloud: bool
     is_public: bool
     display_name: str
@@ -16,7 +16,6 @@ class SourceInput(with_dict):
 @dataclass
 class Source(with_dict):
     id: str
-    source_type: str
     is_cloud: bool
     owner: str
     is_public: bool
@@ -26,7 +25,7 @@ class Source(with_dict):
     icon: Optional[str]=None
 
     def to_input(self) -> SourceInput:
-        return SourceInput(source_type=self.source_type,
+        return SourceInput(id=self.id,
                            is_cloud=self.is_cloud,
                            is_public=self.is_public,
                            display_name=self.display_name,


### PR DESCRIPTION
We're changing source_id from a random UUID to a more contextualized name such as `gsuite` or `manageengine-desktop-central`. This updates `sevco-shell` so it doesn't depends on the source type, which previously represented the more contextualized naming for plugins.